### PR TITLE
Feat/v3 springboot

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,239 @@
+name: CI/CD Pipeline
+
+# ── 트리거 ────────────────────────────────────────────────────
+# main / develop 브랜치 push 시 실행.
+# 관련 경로가 변경된 경우에만 워크플로 실행 (docs-only 변경은 건너뜀).
+on:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - "uou-capstone/**"
+      - "ai-service/**"
+      - "docker-compose*.yml"
+      - "deploy.sh"
+      - ".github/workflows/**"
+
+# ── 전역 변수 ─────────────────────────────────────────────────
+env:
+  GHCR_REGISTRY: ghcr.io
+  SPRING_IMAGE_NAME: ${{ github.repository_owner }}/main-service
+  AI_IMAGE_NAME: ${{ github.repository_owner }}/ai-service
+
+jobs:
+
+  # ── 변경 감지 ──────────────────────────────────────────────
+  detect-changes:
+    name: Detect Changed Paths
+    runs-on: ubuntu-latest
+    outputs:
+      spring: ${{ steps.filter.outputs.spring }}
+      ai: ${{ steps.filter.outputs.ai }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            spring:
+              - "uou-capstone/**"
+              - "docker-compose*.yml"
+              - ".github/workflows/**"
+            ai:
+              - "ai-service/**"
+              - "docker-compose*.yml"
+              - ".github/workflows/**"
+
+  # ── Spring Boot: 테스트 + 빌드 + GHCR 푸시 ────────────────
+  build-spring:
+    name: Build & Push Spring Image
+    needs: detect-changes
+    if: needs.detect-changes.outputs.spring == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_tag: ${{ steps.tag.outputs.IMAGE_TAG }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── 테스트 ────────────────────────────────────────────
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: temurin
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        working-directory: uou-capstone
+        run: chmod +x gradlew
+
+      - name: Run Spring tests
+        working-directory: uou-capstone
+        run: ./gradlew test --no-daemon
+        env:
+          SPRING_PROFILES_ACTIVE: test
+
+      # ── 이미지 태그 계산 ──────────────────────────────────
+      - name: Compute image tag
+        id: tag
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "IMAGE_TAG=${{ github.ref_name }}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      # ── GHCR 로그인 ───────────────────────────────────────
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── Buildx 설정 (레이어 캐시 활용) ───────────────────
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # ── 빌드 & 푸시 ───────────────────────────────────────
+      # SHA 태그(감사/롤백용) + 브랜치-latest 포인터 태그 동시 푸시
+      - name: Build and push Spring image
+        uses: docker/build-push-action@v5
+        with:
+          context: uou-capstone
+          push: true
+          tags: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.SPRING_IMAGE_NAME }}:${{ steps.tag.outputs.IMAGE_TAG }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.SPRING_IMAGE_NAME }}:${{ github.ref_name }}-latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── FastAPI AI Service: 테스트 + 빌드 + GHCR 푸시 ─────────
+  # ai-service/Dockerfile 이 존재해야 이 잡이 실제로 빌드를 수행합니다.
+  # Dockerfile 없이 push 하면 "AI Service ready" 체크 단계에서 잡이 조기 종료(skipped)됩니다.
+  build-ai:
+    name: Build & Push AI Image
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ai == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_tag: ${{ steps.tag.outputs.IMAGE_TAG }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── ai-service/Dockerfile 존재 확인 ──────────────────
+      # Dockerfile 이 없으면 AI팀 준비 전이므로 이후 단계를 건너뜁니다.
+      - name: Check AI Service is ready to build
+        id: ai_ready
+        run: |
+          if [ ! -f "ai-service/Dockerfile" ]; then
+            echo "::warning::ai-service/Dockerfile 이 없습니다. AI_SERVICE_INTEGRATION_SPEC.md 를 AI팀에 전달하세요."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── 테스트 ────────────────────────────────────────────
+      - name: Set up Python 3.11
+        if: steps.ai_ready.outputs.ready == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install AI dependencies
+        if: steps.ai_ready.outputs.ready == 'true'
+        working-directory: ai-service
+        run: pip install -r requirements.txt
+
+      - name: Run AI tests
+        if: steps.ai_ready.outputs.ready == 'true'
+        working-directory: ai-service
+        run: python -m pytest tests/ -v --tb=short
+
+      # ── 이미지 태그 계산 ──────────────────────────────────
+      - name: Compute image tag
+        if: steps.ai_ready.outputs.ready == 'true'
+        id: tag
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "IMAGE_TAG=${{ github.ref_name }}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      # ── GHCR 로그인 ───────────────────────────────────────
+      - name: Log in to GHCR
+        if: steps.ai_ready.outputs.ready == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── Buildx 설정 ───────────────────────────────────────
+      - name: Set up Docker Buildx
+        if: steps.ai_ready.outputs.ready == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      # ── 빌드 & 푸시 ───────────────────────────────────────
+      - name: Build and push AI image
+        if: steps.ai_ready.outputs.ready == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: ai-service
+          push: true
+          tags: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.AI_IMAGE_NAME }}:${{ steps.tag.outputs.IMAGE_TAG }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.AI_IMAGE_NAME }}:${{ github.ref_name }}-latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── EC2 배포 ───────────────────────────────────────────────
+  deploy:
+    name: Deploy to EC2
+    # build-spring / build-ai 중 하나라도 성공하고, 어느 것도 실패하지 않으면 배포
+    needs: [build-spring, build-ai]
+    if: |
+      always() &&
+      (needs.build-spring.result == 'success' || needs.build-ai.result == 'success') &&
+      needs.build-spring.result != 'failure' &&
+      needs.build-ai.result != 'failure'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          # GHCR_TOKEN / GHCR_USERNAME 은 EC2 셸로 전달되어 deploy.sh 내에서 사용
+          envs: GHCR_TOKEN,GHCR_USERNAME
+          script: |
+            export GHCR_TOKEN="${{ secrets.GHCR_TOKEN }}"
+            export GHCR_USERNAME="${{ github.actor }}"
+            bash /home/ubuntu/UOU_Capstone_design_Be_v3/deploy.sh "${{ github.ref_name }}"
+
+      - name: Print deployment summary
+        run: |
+          echo "## Deployment Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 항목 | 값 |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|-----|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 브랜치 | \`${{ github.ref_name }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 커밋 | \`${GITHUB_SHA::7}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Spring 빌드 | ${{ needs.build-spring.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| AI 빌드 | ${{ needs.build-ai.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "| Spring 엔드포인트 | \`:8080\` |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| AI 엔드포인트 | \`:8000\` |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| Spring 엔드포인트 | \`:8081\` |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| AI 엔드포인트 | \`:8001\` |" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# 배포용 환경변수 파일 (실제 비밀값 포함 — 절대 커밋 금지)
+env/*.env
+
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# EC2 배포 스크립트
+#
+# 사용법:
+#   bash deploy.sh <브랜치>
+#   bash deploy.sh main       → docker-compose.main.yml (포트 8080/8000)
+#   bash deploy.sh develop    → docker-compose.develop.yml (포트 8081/8001)
+#
+# 필수 환경변수 (GitHub Actions Secrets 또는 EC2 ~/.bashrc 에 설정):
+#   GHCR_TOKEN      : GHCR pull 권한이 있는 Personal Access Token
+#   GHCR_USERNAME   : GitHub 사용자명 (또는 org명)
+#
+# 롤백 방법:
+#   env/main.env (또는 env/develop.env) 에서
+#   SPRING_IMAGE_TAG / AI_IMAGE_TAG 를 이전 SHA 태그로 수정 후 재실행
+
+set -euo pipefail
+
+REPO_DIR="/home/ubuntu/UOU_Capstone_design_Be_v3"
+TARGET_BRANCH="${1:-develop}"
+
+echo "[deploy] 브랜치: ${TARGET_BRANCH}"
+echo "[deploy] 저장소 디렉토리: ${REPO_DIR}"
+
+# ── 저장소 최신화 ─────────────────────────────────────────────
+cd "$REPO_DIR"
+git pull origin "$TARGET_BRANCH"
+
+# ── GHCR 로그인 ───────────────────────────────────────────────
+echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
+echo "[deploy] GHCR 로그인 완료"
+
+# ── Compose 파일 및 env 파일 선택 ────────────────────────────
+if [ "$TARGET_BRANCH" = "main" ]; then
+  COMPOSE_FILE="docker-compose.main.yml"
+  ENV_FILE="env/main.env"
+else
+  COMPOSE_FILE="docker-compose.develop.yml"
+  ENV_FILE="env/develop.env"
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "[ERROR] ${ENV_FILE} 파일이 없습니다."
+  echo "  cp ${ENV_FILE}.example ${ENV_FILE} 후 실제 값을 채워주세요."
+  exit 1
+fi
+
+echo "[deploy] Compose 파일: ${COMPOSE_FILE}"
+echo "[deploy] 환경 파일: ${ENV_FILE}"
+
+# ── 이미지 pull ───────────────────────────────────────────────
+echo "[deploy] 최신 이미지 pull 중..."
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull
+
+# ── 컨테이너 재기동 ──────────────────────────────────────────
+echo "[deploy] 컨테이너 재기동 중..."
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans
+
+# ── 미사용 이미지 정리 ───────────────────────────────────────
+docker image prune -f
+
+echo "[deploy] 완료 ✓ (브랜치: ${TARGET_BRANCH})"
+echo "[deploy] Spring: http://$(hostname -I | awk '{print $1}'):$([ "$TARGET_BRANCH" = "main" ] && echo 8080 || echo 8081)/api/health"
+echo "[deploy] AI   : http://$(hostname -I | awk '{print $1}'):$([ "$TARGET_BRANCH" = "main" ] && echo 8000 || echo 8001)/health"

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -1,0 +1,113 @@
+# develop 브랜치 배포용 Compose (EC2 — 포트 8081/8001)
+#
+# 사전 준비:
+#   cp env/develop.env.example env/develop.env
+#   (env/develop.env 에 개발용 비밀값 입력)
+#
+# 기동:
+#   docker compose --env-file env/develop.env -f docker-compose.develop.yml pull
+#   docker compose --env-file env/develop.env -f docker-compose.develop.yml up -d
+#
+# 롤백 (특정 SHA 태그로):
+#   env/develop.env 에서 SPRING_IMAGE_TAG / AI_IMAGE_TAG 를 이전 태그로 수정 후 위 명령 재실행
+
+services:
+
+  # ── MySQL ────────────────────────────────────────────────
+  dev-mysql:
+    image: mysql:8.0
+    container_name: dev-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-uoucapstone_dev}
+      MYSQL_USER: ${MYSQL_USER:-appuser}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    volumes:
+      - dev-mysql-data:/var/lib/mysql
+    networks:
+      - dev-network
+    restart: always
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost",
+             "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # ── Redis ─────────────────────────────────────────────────
+  dev-redis:
+    image: redis:alpine
+    container_name: dev-redis
+    volumes:
+      - dev-redis-data:/data
+    command: redis-server --save 60 1 --loglevel warning --appendonly yes
+    networks:
+      - dev-network
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # ── Spring Boot (main-service) ────────────────────────────
+  dev-backend:
+    image: ghcr.io/${GHCR_ORG}/main-service:${SPRING_IMAGE_TAG:-develop-latest}
+    container_name: dev-backend
+    ports:
+      - "8081:8080"
+    environment:
+      # 내부 서비스 디스커버리 (compose 네트워크 내 컨테이너명 고정)
+      MYSQL_HOST: dev-mysql
+      MYSQL_PORT: "3306"
+      SPRING_DATA_REDIS_HOST: dev-redis
+      SPRING_DATA_REDIS_PORT: "6379"
+      AI_SERVICE_BASE_URL: http://dev-ai:8000
+    env_file:
+      - env/develop.env
+    networks:
+      - dev-network
+    depends_on:
+      dev-mysql:
+        condition: service_healthy
+      dev-redis:
+        condition: service_healthy
+    restart: always
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider",
+             "http://localhost:8080/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
+
+  # ── FastAPI AI Service ────────────────────────────────────
+  dev-ai:
+    image: ghcr.io/${GHCR_ORG}/ai-service:${AI_IMAGE_TAG:-develop-latest}
+    container_name: dev-ai
+    ports:
+      - "8001:8000"
+    env_file:
+      - env/develop.env
+    networks:
+      - dev-network
+    restart: always
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider",
+             "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  dev-mysql-data:
+    driver: local
+  dev-redis-data:
+    driver: local
+
+networks:
+  dev-network:
+    driver: bridge

--- a/docker-compose.main.yml
+++ b/docker-compose.main.yml
@@ -1,0 +1,113 @@
+# main 브랜치 배포용 Compose (EC2 — 포트 8080/8000)
+#
+# 사전 준비:
+#   cp env/main.env.example env/main.env
+#   (env/main.env 에 실제 비밀값 입력)
+#
+# 기동:
+#   docker compose --env-file env/main.env -f docker-compose.main.yml pull
+#   docker compose --env-file env/main.env -f docker-compose.main.yml up -d
+#
+# 롤백 (특정 SHA 태그로):
+#   env/main.env 에서 SPRING_IMAGE_TAG / AI_IMAGE_TAG 를 이전 태그로 수정 후 위 명령 재실행
+
+services:
+
+  # ── MySQL ────────────────────────────────────────────────
+  main-mysql:
+    image: mysql:8.0
+    container_name: main-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-uoucapstone}
+      MYSQL_USER: ${MYSQL_USER:-appuser}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    volumes:
+      - main-mysql-data:/var/lib/mysql
+    networks:
+      - main-network
+    restart: always
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost",
+             "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # ── Redis ─────────────────────────────────────────────────
+  main-redis:
+    image: redis:alpine
+    container_name: main-redis
+    volumes:
+      - main-redis-data:/data
+    command: redis-server --save 60 1 --loglevel warning --appendonly yes
+    networks:
+      - main-network
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # ── Spring Boot (main-service) ────────────────────────────
+  main-backend:
+    image: ghcr.io/${GHCR_ORG}/main-service:${SPRING_IMAGE_TAG:-main-latest}
+    container_name: main-backend
+    ports:
+      - "8080:8080"
+    environment:
+      # 내부 서비스 디스커버리 (compose 네트워크 내 컨테이너명 고정)
+      MYSQL_HOST: main-mysql
+      MYSQL_PORT: "3306"
+      SPRING_DATA_REDIS_HOST: main-redis
+      SPRING_DATA_REDIS_PORT: "6379"
+      AI_SERVICE_BASE_URL: http://main-ai:8000
+    env_file:
+      - env/main.env
+    networks:
+      - main-network
+    depends_on:
+      main-mysql:
+        condition: service_healthy
+      main-redis:
+        condition: service_healthy
+    restart: always
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider",
+             "http://localhost:8080/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
+
+  # ── FastAPI AI Service ────────────────────────────────────
+  main-ai:
+    image: ghcr.io/${GHCR_ORG}/ai-service:${AI_IMAGE_TAG:-main-latest}
+    container_name: main-ai
+    ports:
+      - "8000:8000"
+    env_file:
+      - env/main.env
+    networks:
+      - main-network
+    restart: always
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider",
+             "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  main-mysql-data:
+    driver: local
+  main-redis-data:
+    driver: local
+
+networks:
+  main-network:
+    driver: bridge

--- a/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/exam/service/DebateService.java
+++ b/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/exam/service/DebateService.java
@@ -61,17 +61,20 @@ public class DebateService {
         String lectureContent = resolveLectureContent(session);
         String fastApiSessionId = toFastApiSessionId(session.getId());
 
-        Map<String, Object> eventBody = new HashMap<>();
-        eventBody.put("type", "DEBATE_STARTED");
-        eventBody.put("mode", request.getMode() != null ? request.getMode() : "debate");
-        eventBody.put("lecture_content", lectureContent);
-        eventBody.put("exam_content", session.getExamContentJson());
+        // FastAPI EventRequest: type + payload (토론 전용 타입은 FastAPI AppEventType에 있어야 함)
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("mode", request.getMode() != null ? request.getMode() : "debate");
+        payload.put("lecture_content", lectureContent);
+        payload.put("exam_content", session.getExamContentJson());
         if (request.getTopic() != null) {
-            eventBody.put("user_topic", request.getTopic());
+            payload.put("user_topic", request.getTopic());
         }
         if (session.getPriorProfileJson() != null) {
-            eventBody.put("profile", session.getPriorProfileJson());
+            payload.put("profile", session.getPriorProfileJson());
         }
+        Map<String, Object> eventBody = new HashMap<>();
+        eventBody.put("type", "DEBATE_STARTED");
+        eventBody.put("payload", payload);
 
         Map<String, Object> phase1Result = callSessionEvent(fastApiSessionId, eventBody);
 
@@ -118,12 +121,15 @@ public class DebateService {
 
         String fastApiSessionId = toFastApiSessionId(session.getId());
 
+        // FastAPI EventRequest: type + payload (루트에 text 두면 Pydantic이 무시함)
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("question", request.getUserInput());
+        if (session.getDebateHistoryJson() != null) {
+            payload.put("debate_history", session.getDebateHistoryJson());
+        }
         Map<String, Object> eventBody = new HashMap<>();
         eventBody.put("type", "USER_MESSAGE");
-        eventBody.put("text", request.getUserInput());
-        if (session.getDebateHistoryJson() != null) {
-            eventBody.put("debate_history", session.getDebateHistoryJson());
-        }
+        eventBody.put("payload", payload);
 
         Map<String, Object> result = callSessionEvent(fastApiSessionId, eventBody);
 

--- a/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/learning/controller/LearningSessionController.java
+++ b/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/learning/controller/LearningSessionController.java
@@ -76,12 +76,13 @@ public class LearningSessionController {
      * 학습 세션에 AppEvent를 전송하고, FastAPI OrchestrationEngine의 처리 결과를
      * SSE(Server-Sent Events) 스트리밍으로 실시간 수신한다.
      *
-     * 요청 예시 (Spring → FastAPI 변환 후):
+     * 요청 예시 (Spring → FastAPI 변환 후, llm_multi_agent Bridge·Session 계약):
      * {
      *   "type": "USER_MESSAGE",
      *   "lecture_id": 1,
-     *   "payload": { "text": "이 페이지 설명해줘" }
+     *   "payload": { "question": "이 페이지 설명해줘" }
      * }
+     * (구버전 호환: 본문에 {@code text}만 있으면 서비스에서 {@code question}으로 보강)
      *
      * SSE 응답 포맷 (NDJSON 라인별 data 필드):
      * data: {"type":"agent_delta","agent":"explainer","delta":"설명 텍스트..."}

--- a/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/learning/dto/SessionEventRequest.java
+++ b/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/learning/dto/SessionEventRequest.java
@@ -21,7 +21,7 @@ import java.util.Map;
  * - SESSION_ENTERED
  * - START_EXPLANATION_DECISION
  * - PAGE_CHANGED
- * - USER_MESSAGE
+ * - USER_MESSAGE (payload 권장 키: {@code question} — llm_multi_agent / Bridge·Session 계약. {@code text}는 Spring에서 {@code question}으로 보강 가능)
  * - QUIZ_DECISION
  * - QUIZ_TYPE_SELECTED
  * - QUIZ_SUBMITTED

--- a/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/learning/service/LearningSessionService.java
+++ b/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/learning/service/LearningSessionService.java
@@ -117,13 +117,7 @@ public class LearningSessionService {
         log.info("학습 세션 이벤트 스트림: lectureId={}, sessionId={}, eventType={}, viewerPage={}",
                 lectureId, sessionId, eventRequest.getType(), viewerPage);
 
-        Map<String, Object> payload = new LinkedHashMap<>(eventRequest.toPayload());
-        // FastAPI가 payload.current_page / page 없이 세션의 잘못된 페이지(예: 마지막 페이지)를 쓰는 것을 방지
-        if (viewerPage != null) {
-            payload.put("current_page", viewerPage);
-            payload.put("page", viewerPage);
-            payload.put("pageNumber", viewerPage);
-        }
+        Map<String, Object> payload = buildPayloadForFastApi(eventRequest, viewerPage);
 
         Map<String, Object> requestBody = new LinkedHashMap<>();
         requestBody.put("type", eventRequest.getType());
@@ -171,5 +165,40 @@ public class LearningSessionService {
             }
         }
         return null;
+    }
+
+    /**
+     * FastAPI {@code EventRequest} 계약에 맞게 payload를 만든다.
+     * <ul>
+     *   <li>FE가 {@code { "type":"...", "payload": { ... } }} 형태로내면 이중 래핑을 제거한다.</li>
+     *   <li>{@code USER_MESSAGE}: 문서 계약은 {@code payload.question}. 구버전 {@code text}만 있으면 {@code question}으로 복사한다.</li>
+     *   <li>뷰어 페이지 쿼리가 있으면 {@code current_page} 등을 주입한다.</li>
+     * </ul>
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> buildPayloadForFastApi(SessionEventRequest eventRequest, Integer viewerPage) {
+        Map<String, Object> payload = new LinkedHashMap<>(eventRequest.toPayload());
+        if (payload.size() == 1 && payload.get("payload") instanceof Map<?, ?> nested) {
+            payload = new LinkedHashMap<>((Map<String, Object>) nested);
+        }
+
+        if ("USER_MESSAGE".equals(eventRequest.getType())) {
+            Object question = payload.get("question");
+            boolean questionBlank = question == null
+                    || (question instanceof String qs && qs.isBlank());
+            if (questionBlank) {
+                Object text = payload.get("text");
+                if (text != null && StringUtils.hasText(String.valueOf(text))) {
+                    payload.put("question", String.valueOf(text));
+                }
+            }
+        }
+
+        if (viewerPage != null) {
+            payload.put("current_page", viewerPage);
+            payload.put("page", viewerPage);
+            payload.put("pageNumber", viewerPage);
+        }
+        return payload;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces automated build/push and EC2 deploy via GitHub Actions plus new Docker Compose-based runtime, which can directly impact production deployments if misconfigured. Also changes the Spring→FastAPI event payload contract (nested `payload`, `question` vs `text`), which may break AI interactions if the backend/AI versions drift.
> 
> **Overview**
> **Adds an end-to-end CI/CD pipeline**: on `main`/`develop` pushes (scoped by path filters), run Spring tests, optionally run AI tests/build when `ai-service/Dockerfile` exists, build/push images to GHCR with SHA+`*-latest` tags, then deploy to EC2 over SSH and publish a workflow summary.
> 
> **Standardizes EC2 deployment artifacts** by adding `deploy.sh` and branch-specific `docker-compose.main.yml`/`docker-compose.develop.yml` (MySQL/Redis/Spring/AI) driven by per-branch `env/*.env` files (now ignored by `.gitignore`).
> 
> **Aligns Spring→FastAPI session event contracts**: `DebateService` now wraps all event fields under `payload` (and uses `payload.question` for `USER_MESSAGE`), and `LearningSessionService` builds a FastAPI-compatible payload (unwraps nested `payload`, backfills `question` from legacy `text`, and injects viewer page fields).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30e586a7615ea408de3e24f92fd27ca7413792a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->