### PR TITLE
feat : 자동화배포 작업

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -23,8 +23,13 @@ echo "[deploy] 브랜치: ${TARGET_BRANCH}"
 echo "[deploy] 저장소 디렉토리: ${REPO_DIR}"
 
 # ── 저장소 최신화 ─────────────────────────────────────────────
+# git pull 대신 fetch + checkout + reset 사용.
+# pull은 현재 체크아웃된 브랜치에 merge하므로, main/develop 두 환경이
+# 같은 디렉토리를 공유할 때 엉뚱한 브랜치에 merge될 위험이 있음.
 cd "$REPO_DIR"
-git pull origin "$TARGET_BRANCH"
+git fetch origin "$TARGET_BRANCH"
+git checkout "$TARGET_BRANCH"
+git reset --hard "origin/$TARGET_BRANCH"
 
 # ── GHCR 로그인 ───────────────────────────────────────────────
 echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -54,7 +54,7 @@ services:
 
   # ── Spring Boot (main-service) ────────────────────────────
   dev-backend:
-    image: ghcr.io/${GHCR_ORG}/main-service:${SPRING_IMAGE_TAG:-develop-latest}
+    image: ghcr.io/${GHCR_ORG:?GHCR_ORG is not set. Check env/develop.env}/main-service:${SPRING_IMAGE_TAG:-develop-latest}
     container_name: dev-backend
     ports:
       - "8081:8080"
@@ -85,7 +85,7 @@ services:
 
   # ── FastAPI AI Service ────────────────────────────────────
   dev-ai:
-    image: ghcr.io/${GHCR_ORG}/ai-service:${AI_IMAGE_TAG:-develop-latest}
+    image: ghcr.io/${GHCR_ORG:?GHCR_ORG is not set. Check env/develop.env}/ai-service:${AI_IMAGE_TAG:-develop-latest}
     container_name: dev-ai
     ports:
       - "8001:8000"

--- a/docker-compose.main.yml
+++ b/docker-compose.main.yml
@@ -54,7 +54,7 @@ services:
 
   # ── Spring Boot (main-service) ────────────────────────────
   main-backend:
-    image: ghcr.io/${GHCR_ORG}/main-service:${SPRING_IMAGE_TAG:-main-latest}
+    image: ghcr.io/${GHCR_ORG:?GHCR_ORG is not set. Check env/main.env}/main-service:${SPRING_IMAGE_TAG:-main-latest}
     container_name: main-backend
     ports:
       - "8080:8080"
@@ -85,7 +85,7 @@ services:
 
   # ── FastAPI AI Service ────────────────────────────────────
   main-ai:
-    image: ghcr.io/${GHCR_ORG}/ai-service:${AI_IMAGE_TAG:-main-latest}
+    image: ghcr.io/${GHCR_ORG:?GHCR_ORG is not set. Check env/main.env}/ai-service:${AI_IMAGE_TAG:-main-latest}
     container_name: main-ai
     ports:
       - "8000:8000"

--- a/env/develop.env.example
+++ b/env/develop.env.example
@@ -1,0 +1,40 @@
+# =============================================================
+# develop 환경 배포용 환경변수 템플릿
+# 사용법: cp env/develop.env.example env/develop.env
+#         (env/develop.env 는 .gitignore 에 등록되어 커밋되지 않음)
+# =============================================================
+
+# ── GHCR 이미지 태그 ─────────────────────────────────────────
+# CI가 푸시하는 포인터 태그를 기본으로 사용합니다.
+# 롤백 시: develop-<7자리 SHA> 형식의 특정 태그로 변경 후 재배포
+GHCR_ORG=your-github-org
+SPRING_IMAGE_TAG=develop-latest
+AI_IMAGE_TAG=develop-latest
+
+# ── MySQL ────────────────────────────────────────────────────
+MYSQL_ROOT_PASSWORD=change_me_dev_password
+MYSQL_DATABASE=uoucapstone_dev
+MYSQL_USER=appuser
+MYSQL_PASSWORD=change_me_dev_password
+
+# ── Spring Boot ──────────────────────────────────────────────
+SPRING_PROFILES_ACTIVE=prod
+
+# MySQL 접속 (MYSQL_HOST / MYSQL_PORT 는 compose 파일에서 컨테이너명으로 오버라이드됨)
+MYSQL_USERNAME=appuser
+
+# JWT 서명 키 (개발용 — 운영과 다른 키 사용 권장)
+JWT_SECRET=change_me_dev_jwt_secret_key_at_least_32chars
+
+# AI 서비스 내부 통신 키
+AI_SERVICE_SECRET_KEY=change_me_dev_ai_secret_key
+
+# OAuth2 카카오 설정 (개발 도메인)
+KAKAO_REDIRECT_URI=http://your-ec2-ip:8081/login/oauth2/code/kakao
+OAUTH2_FRONTEND_URL=http://localhost:3000
+OAUTH2_REDIRECT_PATH=/auth/callback
+
+# ── FastAPI AI Service ────────────────────────────────────────
+# AI 팀이 필요한 환경변수를 이 섹션에 추가합니다.
+# AI_SECRET_KEY=change_me_dev
+# OPENAI_API_KEY=sk-...

--- a/env/main.env.example
+++ b/env/main.env.example
@@ -1,0 +1,40 @@
+# =============================================================
+# main 환경 배포용 환경변수 템플릿
+# 사용법: cp env/main.env.example env/main.env
+#         (env/main.env 는 .gitignore 에 등록되어 커밋되지 않음)
+# =============================================================
+
+# ── GHCR 이미지 태그 ─────────────────────────────────────────
+# CI가 푸시하는 포인터 태그를 기본으로 사용합니다.
+# 롤백 시: main-<7자리 SHA> 형식의 특정 태그로 변경 후 재배포
+GHCR_ORG=your-github-org
+SPRING_IMAGE_TAG=main-latest
+AI_IMAGE_TAG=main-latest
+
+# ── MySQL ────────────────────────────────────────────────────
+MYSQL_ROOT_PASSWORD=change_me_strong_password
+MYSQL_DATABASE=uoucapstone
+MYSQL_USER=appuser
+MYSQL_PASSWORD=change_me_strong_password
+
+# ── Spring Boot ──────────────────────────────────────────────
+SPRING_PROFILES_ACTIVE=prod
+
+# MySQL 접속 (MYSQL_HOST / MYSQL_PORT 는 compose 파일에서 컨테이너명으로 오버라이드됨)
+MYSQL_USERNAME=appuser
+
+# JWT 서명 키 (최소 32자 이상 랜덤 문자열)
+JWT_SECRET=change_me_very_long_and_random_jwt_secret_key
+
+# AI 서비스 내부 통신 키
+AI_SERVICE_SECRET_KEY=change_me_ai_secret_key
+
+# OAuth2 카카오 설정
+KAKAO_REDIRECT_URI=https://your-domain.com/login/oauth2/code/kakao
+OAUTH2_FRONTEND_URL=https://ai-lms.netlify.app
+OAUTH2_REDIRECT_PATH=/auth/callback
+
+# ── FastAPI AI Service ────────────────────────────────────────
+# AI 팀이 필요한 환경변수를 이 섹션에 추가합니다.
+# AI_SECRET_KEY=change_me
+# OPENAI_API_KEY=sk-...


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deployment/update mechanics and image resolution for both `main` and `develop`, which could break deployments if env files/variables are misconfigured. Runtime app logic is unaffected.
> 
> **Overview**
> Makes `deploy.sh` update code via `fetch` + `checkout` + `reset --hard` instead of `git pull` to avoid accidental cross-branch merges when sharing a directory.
> 
> Updates both compose files to require `GHCR_ORG` (with a clear error) when constructing GHCR image names, and adds `env/main.env.example` and `env/develop.env.example` templates to standardize required deployment variables and image-tag rollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e19ea8ae312af7b09814264f3b445c1f76276d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->