### PR TITLE
refactor : /api/users/check-email 중복 엔드포인트 제거

### DIFF
--- a/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/user/README.md
+++ b/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/user/README.md
@@ -24,6 +24,7 @@
 | `POST /login` | 익명 | 로그인 — Access + Refresh 토큰 발급 (DB 저장 X — 검증은 토큰 자체로) |
 | `POST /logout` | 인증 | 현재 액세스 토큰을 **블랙리스트** 에 추가 (만료 시각까지 유지) |
 | `POST /refresh` | 익명 | Refresh 토큰으로 새 Access 토큰 발급 (현재는 Refresh 회전 없음 — 그대로 재사용) |
+| `GET  /check-email?email=` | 익명 | 회원가입 전 이메일 중복 체크 — IP 기준 30회/분 rate limit (`AuthRateLimitInterceptor`) |
 
 ### 사용자 (`UserController`) prefix: `/api/users`
 
@@ -32,7 +33,6 @@
 | `GET  /me` | 인증 | 내 정보 조회 |
 | `PUT  /password` | 인증 | 비밀번호 변경 — 현재 비밀번호 검증 + 신/확인 일치 검증 |
 | `PUT  /profile` | 인증 | 이름·전화번호·생년월일 수정 |
-| `GET  /check-email?email=` | 익명 | 회원가입 시 중복 체크 |
 | `DELETE /account` | 인증 | 회원 탈퇴 — 비밀번호 재확인 후 cascade 삭제 |
 
 ### OAuth2 (Kakao) — 별도 패키지
@@ -92,8 +92,8 @@ Spring Data JPA 의 underscore-property 표기. `findByUserId` 로 바꾸면 인
 ## 주요 파일
 
 ### Controller
-- `controller/AuthController.java` — signup/login/logout/refresh
-- `controller/UserController.java` — me/password/profile/check-email/delete
+- `controller/AuthController.java` — signup/login/logout/refresh/check-email
+- `controller/UserController.java` — me/password/profile/delete
 
 ### Service
 - `service/AuthService.java` (160줄) — 회원가입·로그인·로그아웃(블랙리스트)·토큰 갱신

--- a/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/user/controller/UserController.java
+++ b/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/domain/user/controller/UserController.java
@@ -47,17 +47,6 @@ public class UserController {
         return ResponseEntity.ok(updatedProfile);
     }
 
-    @Operation(summary = "이메일 중복 확인", description = "회원가입 시 이메일 중복 여부를 확인합니다.")
-    @GetMapping("/check-email")
-    public ResponseEntity<Map<String, Object>> checkEmailAvailability(@RequestParam String email) {
-        boolean available = userService.checkEmailAvailability(email);
-        return ResponseEntity.ok(Map.of(
-                "email", email,
-                "available", available,
-                "message", available ? "사용 가능한 이메일입니다." : "이미 사용 중인 이메일입니다."
-        ));
-    }
-
     @Operation(summary = "회원 탈퇴", description = "로그인한 사용자의 계정을 삭제합니다. 비밀번호 확인이 필요합니다.")
     @DeleteMapping("/account")
     @PreAuthorize("isAuthenticated()")

--- a/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/security/README.md
+++ b/uou-capstone/src/main/java/io/github/uou_capstone/aiplatform/security/README.md
@@ -80,7 +80,7 @@ JWT 인증 + OAuth2(카카오) + 401/403 응답 표준화. Spring Security `Filt
 - `exceptionHandling.authenticationEntryPoint(RestAuthenticationEntryPoint)` + `accessDeniedHandler(JwtAccessDeniedHandler)`
 - `oauth2Login.userInfoEndpoint().userService(CustomOAuth2UserService)`
 - `oauth2Login.successHandler(OAuth2AuthenticationSuccessHandler)` + `failureHandler(OAuth2AuthenticationFailureHandler)`
-- 공개 경로: `/api/auth/**`, `/api/users/check-email`, OAuth2 콜백 등
+- 공개 경로: `/api/auth/**` (이메일 중복 확인 포함), OAuth2 콜백 등
 
 ---
 


### PR DESCRIPTION
회원가입 전 호출되는 이메일 중복 확인은 /api/auth/check-email
(SecurityConfig permitAll + IP rate limit) 로 일원화.
UserController 의 동일 핸들러는 인증 가드 아래 있어 FE 가
호출 시 401/302 redirect 가 발생하던 혼선을 제거.